### PR TITLE
Inheritance traits

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -329,11 +329,11 @@ impl XmlSupertype for AbstractRule {}
 
 impl AbstractRule {
     pub fn cast(self) -> RuleTypes {
-        if let Some(rule) = self.downcast_checked::<AlgebraicRule>() {
+        if let Some(rule) = self.try_downcast::<AlgebraicRule>() {
             RuleTypes::Algebraic(rule)
-        } else if let Some(rule) = self.downcast_checked::<AssignmentRule>() {
+        } else if let Some(rule) = self.try_downcast::<AssignmentRule>() {
             RuleTypes::Assignment(rule)
-        } else if let Some(rule) = self.downcast_checked::<RateRule>() {
+        } else if let Some(rule) = self.try_downcast::<RateRule>() {
             RuleTypes::Rate(rule)
         } else {
             RuleTypes::Other(self)

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,6 +5,7 @@ use crate::xml::{
 };
 use macros::{SBase, XmlWrapper};
 use strum_macros::{Display, EnumString};
+use crate::sbase::SBase;
 
 /// A type-safe representation of an SBML <model> element.
 #[derive(Clone, Debug, XmlWrapper, SBase)]
@@ -45,7 +46,7 @@ impl SbmlModel {
         OptionalChild::new(self.as_xml(), "listOfInitialAssignments", URL_SBML_CORE)
     }
 
-    pub fn rules<T: Rule>(&self) -> OptionalChild<XmlList<T>> {
+    pub fn rules(&self) -> OptionalChild<XmlList<AbstractRule>> {
         OptionalChild::new(self.as_xml(), "listOfRules", URL_SBML_CORE)
     }
 
@@ -297,10 +298,40 @@ impl InitialAssignment {
     }
 }
 
-pub trait Rule: XmlWrapper {
+pub enum RuleEnum {
+    // Other is used to represent rules that are only defined in (hypothetical) SBML extensions
+    // that are not covered by this library.
+    Other(AbstractRule),
+    Algebraic(AlgebraicRule),
+    Assignment(AssignmentRule),
+    Rate(RateRule)
+}
+
+pub trait Rule : SBase {
     fn math(&self) -> OptionalChild<Math> {
         OptionalChild::new(self.as_xml(), "math", URL_MATHML)
     }
+}
+
+#[derive(Clone, Debug, XmlWrapper, SBase)]
+pub struct AbstractRule(XmlElement);
+
+impl Rule for AbstractRule {}
+
+impl AbstractRule {
+
+    pub fn downcast(self) -> RuleEnum {
+        if let Some(rule) = AlgebraicRule::cast(self.clone()) {
+            RuleEnum::Algebraic(rule)
+        } else if let Some(rule) = AssignmentRule::cast(self.clone()) {
+            RuleEnum::Assignment(rule)
+        } else if let Some(rule) = RateRule::cast(self.clone()) {
+            RuleEnum::Rate(rule)
+        } else {
+            RuleEnum::Other(self)
+        }
+    }
+
 }
 
 #[derive(Clone, Debug, XmlWrapper, SBase)]
@@ -308,12 +339,32 @@ pub struct AlgebraicRule(XmlElement);
 
 impl Rule for AlgebraicRule {}
 
+impl AlgebraicRule {
+
+    pub fn cast(rule: AbstractRule) -> Option<AlgebraicRule> {
+        if rule.name() == "algebraicRule" {
+            unsafe { Some(AlgebraicRule::unchecked_cast(rule)) }
+        } else {
+            None
+        }
+    }
+
+}
 #[derive(Clone, Debug, XmlWrapper, SBase)]
 pub struct AssignmentRule(XmlElement);
 
 impl Rule for AssignmentRule {}
 
 impl AssignmentRule {
+
+    pub fn cast(rule: AbstractRule) -> Option<AssignmentRule> {
+        if rule.name() == "assignmentRule" {
+            unsafe { Some(AssignmentRule::unchecked_cast(rule)) }
+        } else {
+            None
+        }
+    }
+
     pub fn variable(&self) -> RequiredProperty<String> {
         RequiredProperty::new(self.as_xml(), "variable")
     }
@@ -325,6 +376,15 @@ pub struct RateRule(XmlElement);
 impl Rule for RateRule {}
 
 impl RateRule {
+
+    pub fn cast(rule: AbstractRule) -> Option<RateRule> {
+        if rule.name() == "rateRule" {
+            unsafe { Some(RateRule::unchecked_cast(rule)) }
+        } else {
+            None
+        }
+    }
+
     pub fn variable(&self) -> RequiredProperty<String> {
         RequiredProperty::new(self.as_xml(), "variable")
     }

--- a/src/xml/mod.rs
+++ b/src/xml/mod.rs
@@ -31,6 +31,10 @@ mod impl_xml_child;
 /// specification Section 3.1.
 mod impl_xml_property_type;
 
+/// Defines [XmlSubtype] and [XmlSupertype] which are helpful for declaring inheritance
+/// hierarchies of [XmlWrapper] types.
+mod xml_inheritance;
+
 pub use crate::xml::impl_xml_child::{
     Child, DynamicChild, OptionalChild, OptionalDynamicChild, RequiredChild, RequiredDynamicChild,
 };
@@ -40,6 +44,7 @@ pub use crate::xml::impl_xml_property::{
 };
 pub use crate::xml::xml_child::{OptionalXmlChild, RequiredXmlChild, XmlChild, XmlChildDefault};
 pub use crate::xml::xml_element::XmlElement;
+pub use crate::xml::xml_inheritance::{XmlNamedSubtype, XmlSubtype, XmlSupertype};
 pub use crate::xml::xml_list::XmlList;
 pub use crate::xml::xml_property::{OptionalXmlProperty, RequiredXmlProperty, XmlProperty};
 pub use crate::xml::xml_property_type::XmlPropertyType;

--- a/src/xml/xml_inheritance.rs
+++ b/src/xml/xml_inheritance.rs
@@ -1,0 +1,82 @@
+use crate::xml::XmlWrapper;
+
+/// Implemented by [XmlWrapper] instances that represent a variant of a more generic `Super` type.
+///
+/// In general, we expect the classic OOP substitution principle to hold. That is, every instance
+/// of a sub-type can be used as a valid instance of the super type. However, casting a super type
+/// into a sub-type involves a runtime check and can fail.
+pub trait XmlSubtype<Super: XmlSupertype>: XmlWrapper {
+    /// Try to cast the value of `Super` type as `Self`.
+    ///
+    /// Typically, this checks the name of the XML tag, but in som cases could also
+    /// involve other properties of the XML tag.
+    fn cast_from_super_checked(value: &Super) -> Option<Self>;
+
+    /// Create a value of `Self` from the provided `Super` type.
+    /// Panics when the cast is not successful.
+    fn cast_from_super(value: &Super) -> Self {
+        Self::cast_from_super_checked(value).unwrap_or_else(|| {
+            panic!(
+                "Cannot cast element of type `{}` as type `{}`.",
+                std::any::type_name::<Super>(),
+                std::any::type_name::<Self>()
+            );
+        })
+    }
+
+    /// Cast the value of this subtype as the `Super` type.
+    ///
+    /// This cast should be always valid, hence we can provide a default implementation.
+    fn upcast(&self) -> Super {
+        // Safety follows from the "contracts" prescribed for implementations of `XmlSubtype`.
+        unsafe { Super::unchecked_cast(self.xml_element().clone()) }
+    }
+}
+
+/// A counterpart for [XmlSubtype]. It provides default implementations for various utility
+/// methods that are potentially more idiomatic than calling [XmlSubtype] directly.
+///
+/// Unfortunately, Rust does not allow us to provide a blanket implementation
+pub trait XmlSupertype: XmlWrapper {
+    /// Try to cast the value of `Self` as the value of `Sub` type. The `Sub` type must
+    /// implement the appropriate [XmlSubtype] trait.
+    ///
+    /// See also [XmlSubtype::cast_from_super_checked].
+    fn downcast_checked<Sub: XmlSubtype<Self>>(&self) -> Option<Sub> {
+        Sub::cast_from_super_checked(self)
+    }
+
+    /// Cast the value of `Self` as the value of `Sub` type.
+    /// Panics when the cast is unsuccessful.
+    ///
+    /// See also [XmlSubtype::cast_from_super].
+    fn downcast<Sub: XmlSubtype<Self>>(&self) -> Sub {
+        Sub::cast_from_super(self)
+    }
+
+    /// Cast the value of `Sub` as `Self`. This cast always succeeds.
+    fn cast_from_sub<Sub: XmlSubtype<Self>>(value: &Sub) -> Self {
+        value.upcast()
+    }
+
+    /// Returns `true` if `self` is of type `Sub`, i.e. it can be safely casted to `Sub`.
+    fn is_instance<Sub: XmlSubtype<Self>>(&self) -> bool {
+        self.downcast_checked::<Sub>().is_some()
+    }
+}
+
+/// A "helper" trait that provides a default implementation for [XmlSubtype] as long as the
+/// type is only determined by the name of the XML tag and the name is known at compile time.
+pub trait XmlNamedSubtype<Super: XmlSupertype>: XmlSubtype<Super> {
+    fn expected_tag_name() -> &'static str;
+}
+
+impl<Super: XmlSupertype, Sub: XmlNamedSubtype<Super>> XmlSubtype<Super> for Sub {
+    fn cast_from_super_checked(value: &Super) -> Option<Self> {
+        if value.tag_name() == Self::expected_tag_name() {
+            unsafe { Some(Self::unchecked_cast(value.xml_element().clone())) }
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the ability to implement inheritance-like behavior through traits. 

In particular, the `Super` type is expected to implement the `XmlSupertype` trait. This is "free" since `XmlSupertype` only provides default implementations. However, we don't implement `XmlSupertype` automatically for every `XmlWrapper` to avoid adding unnecessary methods to types that won't ever use them. 

Afterwards, any `Sub` type which "inherits" from `Super` should implement `XmlSubtype<Super>` (or `XmlNamedSubtype<Super>` if the type compatibility only depends on the tag name, which is the usual case).

Overall, these traits provide the following methods (most functionality is present both on the `Super` and `Sub` types, just with different names):

 - `Super::downcast(&self)` (res. `Super::try_downcast(&self)`) and `Sub::cast_from_super(&Super)` (res. `Sub::try_cast_from_super(&Super)`) perform either a panicking or safe conversion from `Super` to `Sub`.
 - `Super::cast_from_sub(&Sub)` and `Sub::upcast(&self)` perform the infallible conversion from `Sub` to `Super`.
 - `Super::is_instance<Sub>(&self)` allows checking if the cast from `Super` to `Sub` can succeed.